### PR TITLE
Add flake8-annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [flake8-mypy](https://github.com/ambv/flake8-mypy) - Plugin for flake8 integrating mypy.
 - [flake8-pyi](https://github.com/ambv/flake8-pyi) - Plugin for Flake8 that provides specializations for type hinting stub files.
 - [flake8-annotations-complexity](https://github.com/best-doctor/flake8-annotations-complexity) - Plugin for flake8 to validate annotations complexity.
+- [flake8-annotations](https://github.com/python-discord/flake8-annotations) - Plugin for flake8 to check for presence of type annotations in function definitions.
 
 ### Testing
 


### PR DESCRIPTION
Hello! Would like to propose the addition of [`flake8-annotations`](https://github.com/python-discord/flake8-annotations) to the linting section of this list.

`flake8-annotations` is a plugin we've developed for [flake8](http://flake8.pycqa.org/en/latest/) that detects the absence of [PEP 3107-style](https://www.python.org/dev/peps/pep-3107/) function annotations and [PEP 484-style](https://www.python.org/dev/peps/pep-0484/#type-comments) type comments.