### PR TITLE
Add `typical` to list of libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 ## Dynamic type checkers
 
 - [pytypes](https://github.com/Stewori/pytypes) - Provides a rich set of utilities for runtime typechecking.
-- [pydantic](https://github.com/samuelcolvin/pydantic) - Data parsing using Python type hinting. Supports dataclasses.
+- [pydantic](https://github.com/samuelcolvin/pydantic) - Data parsing using Python type hinting. 
 - [typeguard](https://github.com/agronholm/typeguard) - Another one runtime type checker.
+- [typical](https://typical.seandstewart.io/) - Data parsing and automatic type-coercion using type hinting. Supports      dataclasses and function signatures.
 
 ## Stub packages
 
@@ -75,6 +76,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [mypyc](https://github.com/python/mypy/tree/master/mypyc) - Compiles mypy-annotated, statically typed Python modules into CPython C extensions.
 - [typing_inspect](https://github.com/ilevkivskyi/typing_inspect) - The typing_inspect module defines experimental API for runtime inspection of types defined in the Python standard typing module.
 - [typing-json](https://pypi.org/project/typing-json/) - Lib for working with typed objects and JSON.   
+- [typical](https://typical.seandstewart.io/) - Lib for inspecting and coercing builtin types, custom user-defined types, and the types defined in the Python standard typing module at runtime.
 
 ### Mypy plugins
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [pytypes](https://github.com/Stewori/pytypes) - Provides a rich set of utilities for runtime typechecking.
 - [pydantic](https://github.com/samuelcolvin/pydantic) - Data parsing using Python type hinting. Supports dataclasses.
 - [typeguard](https://github.com/agronholm/typeguard) - Another one runtime type checker.
-- [typical](https://typical.seandstewart.io/) - Data parsing and automatic type-coercion using type hinting. Supports      dataclasses, standard classes, function signatures, and more.
+- [typical](https://github.com/seandstewart/typical/) - Data parsing and automatic type-coercion using type hinting. Supports dataclasses, standard classes, function signatures, and more.
 
 ## Stub packages
 
@@ -76,7 +76,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [mypyc](https://github.com/python/mypy/tree/master/mypyc) - Compiles mypy-annotated, statically typed Python modules into CPython C extensions.
 - [typing_inspect](https://github.com/ilevkivskyi/typing_inspect) - The typing_inspect module defines experimental API for runtime inspection of types defined in the Python standard typing module.
 - [typing-json](https://pypi.org/project/typing-json/) - Lib for working with typed objects and JSON.   
-- [typical](https://typical.seandstewart.io/) - Lib for inspecting and coercing builtin types, custom user-defined types, and the types defined in the Python standard typing module at runtime.
+- [typical](https://github.com/seandstewart/typical/) - Lib for inspecting and coercing builtin types, custom user-defined types, and the types defined in the Python standard typing module at runtime.
 
 ### Mypy plugins
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 ## Dynamic type checkers
 
 - [pytypes](https://github.com/Stewori/pytypes) - Provides a rich set of utilities for runtime typechecking.
-- [pydantic](https://github.com/samuelcolvin/pydantic) - Data parsing using Python type hinting. 
+- [pydantic](https://github.com/samuelcolvin/pydantic) - Data parsing using Python type hinting. Supports dataclasses.
 - [typeguard](https://github.com/agronholm/typeguard) - Another one runtime type checker.
-- [typical](https://typical.seandstewart.io/) - Data parsing and automatic type-coercion using type hinting. Supports      dataclasses and function signatures.
+- [typical](https://typical.seandstewart.io/) - Data parsing and automatic type-coercion using type hinting. Supports      dataclasses, standard classes, function signatures, and more.
 
 ## Stub packages
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [mypyc](https://github.com/python/mypy/tree/master/mypyc) - Compiles mypy-annotated, statically typed Python modules into CPython C extensions.
 - [typing_inspect](https://github.com/ilevkivskyi/typing_inspect) - The typing_inspect module defines experimental API for runtime inspection of types defined in the Python standard typing module.
 - [typing-json](https://pypi.org/project/typing-json/) - Lib for working with typed objects and JSON.   
-- [typical](https://github.com/seandstewart/typical/) - Lib for inspecting and coercing builtin types, custom user-defined types, and the types defined in the Python standard typing module at runtime.
 
 ### Mypy plugins
 


### PR DESCRIPTION
I was linked here from py-slackers. Great to have a list like this! 

This PR adds [typical](https://github.com/seandstewart/typical/) to your list of typing libraries.