### PR TITLE
Add wsgitypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [ordered-set-stubs](https://github.com/rominf/ordered-set-stubs) - Stubs for [OrderedSet](https://github.com/LuminosoInsight/ordered-set).
 - [pyspark-stubs](https://github.com/zero323/pyspark-stubs) - Stubs for [PySpark](https://spark.apache.org/docs/latest/api/python/index.html).
 - [pythonista-stubs](https://github.com/hbmartin/pythonista-stubs) - Stubs for [Pythonista](http://omz-software.com/pythonista/docs/ios/).
+- [wsgitypes](https://github.com/shabbyrobe/wsgitypes) - Typing for WSGI application implementers. These are not stub files, they're interfaces you mark support for to help typecheck WSGI conformance.
 
 
 ## Tools


### PR DESCRIPTION
We've been looking for ways to type our WSGI middleware for ages. This got a lot easier with TypedDicts. There's still some things that aren't ideal about it but this really helped us bring a lot of extra type safety to a previously very loose codebase. It may help others do the same.