### PR TITLE
data-science-types stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [pyspark-stubs](https://github.com/zero323/pyspark-stubs) - Stubs for [PySpark](https://spark.apache.org/docs/latest/api/python/index.html).
 - [pythonista-stubs](https://github.com/hbmartin/pythonista-stubs) - Stubs for [Pythonista](http://omz-software.com/pythonista/docs/ios/).
 - [wsgitypes](https://github.com/shabbyrobe/wsgitypes) - Typing for WSGI application implementers. These are not stub files, they're interfaces you mark support for to help typecheck WSGI conformance.
+- [data-science-types](https://github.com/predictive-analytics-lab/data-science-types) - Stubs for [NumPy](http://github.com/numpy/numpy), [pandas](https://github.com/pandas-dev/pandas), and [Matplotlib](https://github.com/matplotlib/matplotlib).
 
 ## Backports and improvements
 


### PR DESCRIPTION
[data-science-types](https://github.com/predictive-analytics-lab/data-science-types) - Stubs for [NumPy](http://github.com/numpy/numpy), [pandas](https://github.com/pandas-dev/pandas), and [Matplotlib](https://github.com/matplotlib/matplotlib).

Fixes #38