### PR TITLE
More tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 
 ## Static type checkers
 
-- [mypy](https://github.com/python/mypy) - Optional static typing for Python 3 and 2 (PEP 484).
-- [pyanalyze](https://github.com/quora/pyanalyze) - Extensible static analyzer and type checker for Python.
+- [mypy](https://github.com/python/mypy) - Optional static typing (PEP 484).
+- [pyanalyze](https://github.com/quora/pyanalyze) - Extensible static analyzer and type checker.
 - [pycharm](https://www.jetbrains.com/pycharm/) - IDE for Professional Developers.
-- [pyre](https://pyre-check.org/) - Performant type-checker for Python 3.
+- [pyre](https://pyre-check.org/) - Performant type-checker.
 - [pyright](https://github.com/Microsoft/pyright) - Fast type checker meant for large Python source bases. It can run in a “watch” mode and performs fast incremental updates when files are modified.
-- [pytype](https://github.com/google/pytype) - Tool to check and infer types for Python code - without requiring type annotations.
+- [pytype](https://github.com/google/pytype) - Tool to check and infer types - without requiring type annotations.
 
 ## Dynamic type checkers
 
@@ -51,7 +51,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [pythonista-stubs](https://github.com/hbmartin/pythonista-stubs) - Stubs for [Pythonista](http://omz-software.com/pythonista/docs/ios/).
 - [sqlalchemy-stubs](https://github.com/dropbox/sqlalchemy-stubs) - Stubs for [SQLAlchemy](https://github.com/sqlalchemy/sqlalchemy).
 - [torchtyping](https://github.com/patrick-kidger/torchtyping) - Enhanced type annotations for [pytorch](https://pytorch.org/).
-- [typeshed](https://github.com/python/typeshed) - Collection of library stubs for Python, with static types.
+- [typeshed](https://github.com/python/typeshed) - Collection of library stubs, with static types.
 - [wsgitypes](https://github.com/shabbyrobe/wsgitypes) - Typing for WSGI application implementers. These are not stub files, they're interfaces you mark support for to help typecheck WSGI conformance.
 
 ## Additional types
@@ -90,25 +90,25 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 
 ### Working with types
 
-- [com2ann](https://github.com/ilevkivskyi/com2ann) - Tool for translation of type comments to type annotations in Python.
+- [com2ann](https://github.com/ilevkivskyi/com2ann) - Tool for translation of type comments to type annotations.
 - [merge-pyi](https://github.com/google/pytype/tree/master/pytype/tools/merge_pyi) - Part of pytype toolchain, applies stub files onto source code.
 - [mypy-protobuf](https://github.com/dropbox/mypy-protobuf) - Tool to generate mypy stubs from protobufs.
 - [mypy-silent](https://github.com/whtsky/mypy-silent/) - Silence mypy by adding or removing code comments.
 - [mypyc](https://github.com/python/mypy/tree/master/mypyc) - Compiles mypy-annotated, statically typed Python modules into CPython C extensions.
 - [retype](https://github.com/ambv/retype) - Another tool to apply stubs to code.
-- [typing-inspect](https://github.com/ilevkivskyi/typing_inspect) - The typing_inspect module defines experimental API for runtime inspection of types defined in the Python standard typing module.
+- [typing-inspect](https://github.com/ilevkivskyi/typing_inspect) - The typing_inspect module defines experimental API for runtime inspection of types defined in the `typing` module.
 - [typing-json](https://pypi.org/project/typing-json/) - Lib for working with typed objects and JSON.
 
 ### Helper tools to add annotations to existing code
 
 - [autotyper](https://github.com/JelleZijlstra/autotyper) - Automatically add simple return type annotations for functions (bool, None, Optional).
-- [monkeytype](https://github.com/instagram/MonkeyType) - Collects runtime types of function arguments and return values, and can automatically generate stub files or even add draft type annotations directly to your Python code based on the types collected at runtime.
+- [monkeytype](https://github.com/instagram/MonkeyType) - Collects runtime types of function arguments and return values, and can automatically generate stub files or even add draft type annotations directly to your code based on the types collected at runtime.
 - [pyannotate](https://github.com/dropbox/pyannotate) - Insert annotations into your source code based on call arguments and return types observed at runtime.
 - [pyre infer](https://github.com/facebook/pyre-check) - Pyre has a powerful feature for migrating codebases to a typed format. The [infer](https://pyre-check.org/docs/pysa-coverage/) command-line option ingests a file or directory, makes educated guesses about the types used, and applies the annotations to the files.
 - [pytest-annotate](https://github.com/kensho-technologies/pytest-annotate) - Pyannotate plugin for pytest.
 - [pytest-monkeytype](https://github.com/mariusvniekerk/pytest-monkeytype) - MonkeyType plugin for pytest.
 - [pytype annotate-ast](https://github.com/google/pytype/tree/master/pytype/tools/annotate_ast) - A work-in-progress tool to annotate the nodes of an AST with their Python types.
-- [type4py](https://github.com/saltudelft/type4py) - Deep Similarity Learning-Based Type Inference for Python.
+- [type4py](https://github.com/saltudelft/type4py) - Deep Similarity Learning-Based Type Inference.
 - [typilus](https://github.com/typilus/typilus) - A deep learning algorithm for predicting types in Python. Also available as a [GitHub action](https://github.com/typilus/typilus-action)
 
 ### Mypy plugins

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [Static type checkers](#static-type-checkers)
 - [Dynamic type checkers](#dynamic-type-checkers)
 - [Stub packages](#stub-packages)
+- [Additional types](#additional-types)
 - [Backports and improvements](#backports-and-improvements)
 - [Tools](#tools)
 - [Integrations](#integrations)
@@ -48,18 +49,19 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [PyQt5-stubs](https://github.com/stlehmann/PyQt5-stubs) - Stubs for [PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro).
 - [pyspark-stubs](https://github.com/zero323/pyspark-stubs) - Stubs for [PySpark](https://spark.apache.org/docs/latest/api/python/index.html).
 - [pythonista-stubs](https://github.com/hbmartin/pythonista-stubs) - Stubs for [Pythonista](http://omz-software.com/pythonista/docs/ios/).
-<!--lint disable double-link-->
-- [returns](https://github.com/dry-python/returns) - Stubs for [returns](https://github.com/dry-python/returns).
-<!--lint enable double-link-->
 - [sqlalchemy-stubs](https://github.com/dropbox/sqlalchemy-stubs) - Stubs for [SQLAlchemy](https://github.com/sqlalchemy/sqlalchemy).
 - [torchtyping](https://github.com/patrick-kidger/torchtyping) - Enhanced type annotations for [pytorch](https://pytorch.org/).
 - [typeshed](https://github.com/python/typeshed) - Collection of library stubs for Python, with static types.
 - [wsgitypes](https://github.com/shabbyrobe/wsgitypes) - Typing for WSGI application implementers. These are not stub files, they're interfaces you mark support for to help typecheck WSGI conformance.
 
+## Additional types
+
+- [returns](https://github.com/dry-python/returns) - Make your functions return something meaningful, typed, and safe.
+- [typet](https://github.com/contains-io/typet) - Length-bounded types, dynamic object validation.
+
 ## Backports and improvements
 
 - [typed-ast](https://github.com/python/typed_ast) - Modified fork of CPython's ast module that parses `# type:` comments.
-- [typet](https://github.com/contains-io/typet) - Length-bounded types, dynamic object validation.
 - [typing-extensions](https://github.com/python/typing/tree/master/typing_extensions) - Backported and experimental type hints.
 - [typing-utils](https://github.com/bojiang/typing_utils) - Backport 3.8+ runtime typing utils(for eg: get_origin) & add issubtype & more.
 - [typingplus](https://github.com/contains-io/typingplus/) - Backport support, dynamic is_instance and cast for abstract types.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [beartype](https://github.com/beartype/beartype) - Unbearably fast `O(1)` runtime type-checking in pure Python.
 - [pydantic](https://github.com/samuelcolvin/pydantic) - Data parsing using Python type hinting. Supports dataclasses.
 - [pytypes](https://github.com/Stewori/pytypes) - Provides a rich set of utilities for runtime typechecking.
+- [strongtyping](https://github.com/FelixTheC/strongtyping) - Decorator which checks whether the function is called with the correct type of parameters.
 - [typeguard](https://github.com/agronholm/typeguard) - Another one runtime type checker.
 - [typical](https://github.com/seandstewart/typical/) - Data parsing and automatic type-coercion using type hinting. Supports dataclasses, standard classes, function signatures, and more.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 
 ## Additional types
 
+- [meiga](https://github.com/alice-biometrics/meiga) - Simple, typed and monad-based Result type.
+- [option](https://github.com/MaT1g3R/option) - Rust like Option and Result types.
+- [phantom-types](https://github.com/antonagestam/phantom-types) - Phantom types.
 - [returns](https://github.com/dry-python/returns) - Make your functions return something meaningful, typed, and safe.
+- [safetywrap](https://github.com/mplanchard/safetywrap) - Fully typesafe, Rust-like Result and Option types.
 - [typet](https://github.com/contains-io/typet) - Length-bounded types, dynamic object validation.
 
 ## Backports and improvements
@@ -76,7 +80,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [flake8-pyi](https://github.com/ambv/flake8-pyi) - Plugin for Flake8 that provides specializations for type hinting stub files.
 - [flake8-typing-imports](https://github.com/asottile/flake8-typing-imports) - Plugin which checks that typing imports are properly guarded.
 - [flake8-typing-only-imports](https://github.com/sondrelg/flake8-typing-only-imports) - flake8 plugin that helps identify which imports to put into type-checking blocks, and how to adjust your type annotations once imports are moved.
-- [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide) - The strictest and most opinionated python linter ever.
+- [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide) - The strictest and most opinionated Python linter ever.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 
 - [emacs-flycheck-mypy](https://github.com/lbolla/emacs-flycheck-mypy) - Mypy integration for Emacs.
 - [linter-mypy](https://atom.io/packages/linter-mypy) - Mypy integration for Atom.
-- [mypy-PyCharm-plugin](https://github.com/dropbox/mypy-PyCharm-plugin) - Mypy integration for PyCharm.
+- [mypy-pycharm-plugin](https://github.com/dropbox/mypy-PyCharm-plugin) - Mypy integration for PyCharm.
+- [pylance](https://github.com/microsoft/pylance-release) - PyRight integration for VSCode.
 - [vim-mypy](https://github.com/Integralist/vim-mypy) - Mypy integration for Vim.
 
 ## Articles

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 
 ## Stub packages
 
+- [asgiref](https://github.com/django/asgiref) - ASGI specification, provides [asgiref.typing](https://github.com/django/asgiref/blob/main/asgiref/typing.py) module with type annotations for ASGI servers.
 - [boto3-stubs](https://github.com/vemel/mypy_boto3_builder) - Stubs for [boto3](https://github.com/boto/boto3).
 - [botostubs](https://github.com/jeshan/botostubs) - Gives you code assistance for any boto3 API in any IDE.
 - [data-science-types](https://github.com/predictive-analytics-lab/data-science-types) - Stubs for [numpy](http://github.com/numpy/numpy), [pandas](https://github.com/pandas-dev/pandas), and [matplotlib](https://github.com/matplotlib/matplotlib).

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 
 - [emacs-flycheck-mypy](https://github.com/lbolla/emacs-flycheck-mypy) - Mypy integration for Emacs.
 - [linter-mypy](https://atom.io/packages/linter-mypy) - Mypy integration for Atom.
+- [mypy-playground](https://github.com/ymyzk/mypy-playground) - Online playground for mypy.
 - [mypy-pycharm-plugin](https://github.com/dropbox/mypy-PyCharm-plugin) - Mypy integration for PyCharm.
 - [pylance](https://github.com/microsoft/pylance-release) - PyRight integration for VSCode.
 - [vim-mypy](https://github.com/Integralist/vim-mypy) - Mypy integration for Vim.


### PR DESCRIPTION
1. Add more tools, add section "Additional types", close #64 and #66 
2. Remove "for Python" from tools descriptions, as advised by `contributing.md`