### PR TITLE
Add zuban type checker and remove pyre infer from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [pycroscope](https://github.com/JelleZijlstra/pycroscope) - A semi-static type checker for Python code. It imports the modules it type checks, enabling `pycroscope` to understand many dynamic constructs that other type checkers will reject. This makes it possible to extend `pycroscope` with plugins that interact directly with your code.
 - [pytype](https://github.com/google/pytype) - Tool to check and infer types - without requiring type annotations.
 - [ty](https://github.com/astral-sh/ty) - An extremely fast Python type checker, written in Rust, from the creators of Ruff and uv.
+- [zuban](https://github.com/zubanls/zuban) - A Mypy-compatible Python type checker and Language Server built in Rust
 
 ## Dynamic type checkers
 
@@ -122,13 +123,10 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [no_implicit_optional](https://github.com/hauntsaninja/no_implicit_optional) - A codemod to make your implicit optional type hints [PEP 484](https://peps.python.org/pep-0484/#union-types) compliant.
 - [pyannotate](https://github.com/dropbox/pyannotate) - Insert annotations into your source code based on call arguments and return types observed at runtime.
 - [PyTypes](https://github.com/pvs-hd-tea/PyTypes) - Infer Types by Python Tracing.
-- [pyre infer](https://github.com/facebook/pyre-check) - Pyre has a powerful feature for migrating codebases to a typed format. The [infer](https://pyre-check.org/docs/pysa-coverage/) command-line option ingests a file or directory, makes educated guesses about the types used, and applies the annotations to the files.
 - [pytest-annotate](https://github.com/kensho-technologies/pytest-annotate) - Pyannotate plugin for pytest.
 - [pytest-monkeytype](https://github.com/mariusvniekerk/pytest-monkeytype) - MonkeyType plugin for pytest.
 - [pytype annotate-ast](https://github.com/google/pytype/tree/master/pytype/tools/annotate_ast) - A work-in-progress tool to annotate the nodes of an AST with their Python types.
 - [RightTyper](https://github.com/RightTyper/RightTyper) - A tool that generates types for your function arguments and return values. RightTyper lets your code run at nearly full speed with almost no memory overhead.
-- [type4py](https://github.com/saltudelft/type4py) - Deep Similarity Learning-Based Type Inference.
-- [typilus](https://github.com/typilus/typilus) - A deep learning algorithm for predicting types in Python. Also available as a [GitHub action](https://github.com/typilus/typilus-action)
 - [auto-optional](https://github.com/Luttik/auto-optional) - Makes typed arguments Optional when the default argument is `None`.
 
 ### Mypy plugins

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Collection of awesome Python types, stubs, plugins, and tools to work with them.
 - [pycroscope](https://github.com/JelleZijlstra/pycroscope) - A semi-static type checker for Python code. It imports the modules it type checks, enabling `pycroscope` to understand many dynamic constructs that other type checkers will reject. This makes it possible to extend `pycroscope` with plugins that interact directly with your code.
 - [pytype](https://github.com/google/pytype) - Tool to check and infer types - without requiring type annotations.
 - [ty](https://github.com/astral-sh/ty) - An extremely fast Python type checker, written in Rust, from the creators of Ruff and uv.
-- [zuban](https://github.com/zubanls/zuban) - A Mypy-compatible Python type checker and Language Server built in Rust
+- [zuban](https://github.com/zubanls/zuban) - A Mypy-compatible Python type checker and Language Server built in Rust.
 
 ## Dynamic type checkers
 


### PR DESCRIPTION
- Added the `zuban` typechecker now that it is open source.
- removed the `pyre infer` command (most of the modern typecheckers now have and expose this functionality as a first-class command)
- removed 'type4py` and `typilus` obsolete tools, that were unmaintained for several years